### PR TITLE
CI release tagging

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,16 +3,16 @@ name: Build
 on:
   workflow_dispatch:
     inputs:
-      version:
+      tag:
         required: true
         type: string
-        description: a valid semver
+        description: tag to be added to docker images and git repo
   workflow_call:
     inputs:
-      version:
+      tag:
         required: true
         type: string
-        description: a valid semver
+        description:  tag to be added to docker images and git repo
 
 jobs:
   Build:
@@ -34,7 +34,7 @@ jobs:
           images: |
             sgn0/snapshot-bump-action
           tags: |
-            type=semver,pattern=v{{major}},value=${{ inputs.version }}
+            type=raw,value=${{ inputs.tag }}
       - name: Build and push snapshot-bump
         uses: docker/build-push-action@v3
         with:
@@ -50,7 +50,7 @@ jobs:
           images: |
             sgn0/confluence-action
           tags: |
-            type=semver,pattern=v{{major}},value=${{ inputs.version }}
+            type=raw,value=${{ inputs.tag }}
       - name: Build and push confluence
         uses: docker/build-push-action@v3
         with:
@@ -66,7 +66,7 @@ jobs:
           images: |
             sgn0/nuget-publish-action
           tags: |
-            type=semver,pattern=v{{major}},value=${{ inputs.version }}
+            type=raw,value=${{ inputs.tag }}
       - name: Build and push nuget
         uses: docker/build-push-action@v3
         with:
@@ -82,7 +82,7 @@ jobs:
           images: |
             sgn0/config-service-action
           tags: |
-            type=semver,pattern=v{{major}},value=${{ inputs.version }}
+            type=raw,value=${{ inputs.tag }}
       - name: Build and push config
         uses: docker/build-push-action@v3
         with:
@@ -98,8 +98,7 @@ jobs:
           images: |
             sgn0/csharp-build-env
           tags: |
-            type=semver,pattern=v{{major}},value=${{ inputs.version }}
-            type=semver,pattern=v{{version}},value=${{ inputs.version }}
+            type=raw,value=${{ inputs.tag }}
       - name: Build and push sbt-unity
         uses: docker/build-push-action@v3
         with:
@@ -115,12 +114,12 @@ jobs:
           images: |
             sgn0/sbt-unity-action
           tags: |
-            type=semver,pattern=v{{major}},value=${{ inputs.version }}
+            type=raw,value=${{ inputs.tag }}
       - name: Build and push sbt-unity
         uses: docker/build-push-action@v3
         with:
           context: ./sbt-unity/sbt-image
           push: true
-          build-args: "tag=v${{ inputs.version }}"
+          build-args: "tag=${{ inputs.tag }}"
           tags: "${{ steps.sbt-image-meta.outputs.tags }}"
           labels: "${{ steps.sbt-image-meta.outputs.labels }}"

--- a/.github/workflows/develop-build.yml
+++ b/.github/workflows/develop-build.yml
@@ -1,0 +1,17 @@
+name: develop-build
+
+on:
+  push:
+    branches:
+      - develop
+  workflow_dispatch:
+
+jobs:
+  build:
+    needs: prep-releaseaction interpolation
+    if: needs.prep-release.outputs.release_created
+    secrets: inherit
+    uses: './.github/workflows/build.yml'
+    with:
+      tag: develop
+

--- a/.github/workflows/release-prep.yml
+++ b/.github/workflows/release-prep.yml
@@ -12,6 +12,7 @@ jobs:
     outputs:
       release_created: ${{ steps.release-please.outputs.release_created }}
       version: ${{ steps.release-please.outputs.version }}
+      major: ${{ steps.release-please.outputs.major }}
     steps:
       - id: 'release-please'
         uses: google-github-actions/release-please-action@v3
@@ -20,12 +21,12 @@ jobs:
           default-branch: main
 
   build:
-    needs: prep-release
+    needs: prep-releaseaction interpolation
     if: needs.prep-release.outputs.release_created
     secrets: inherit
     uses: './.github/workflows/build.yml'
     with:
-      version: ${{ needs.prep-release.outputs.version }}
+      tag: v${{ needs.prep-release.outputs.major }}
 
   update-develop-branch:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -34,3 +34,8 @@ If you don't use conventional commits, then you can inform release-please of you
 git commit --allow-empty -m "chore: release 2.0.0" -m "Release-As: 2.0.0"
 ```
 Push that to `main` to kick off the release process.
+
+## Note
+
+Docker based actions explicitly reference `v2` tags. Next time we do a major version update, we'll want to update these as well.
+We may also want to factor the actions into their own repos so they can be versioned individually at that time.

--- a/config/action.yml
+++ b/config/action.yml
@@ -21,6 +21,6 @@ inputs:
     default: false
 runs:
   using: 'docker'
-  image: docker://sgn0/config-service-action:main
+  image: docker://sgn0/config-service-action:v2
   entrypoint: '/config-service.sh'
   

--- a/confluence/action.yml
+++ b/confluence/action.yml
@@ -35,5 +35,5 @@ inputs:
     default: 'false'
 runs:
   using: 'docker'
-  image: docker://sgn0/confluence-action:main
+  image: docker://sgn0/confluence-action:v2
   entrypoint: '/confluence.sh'

--- a/nuget-publish/action.yml
+++ b/nuget-publish/action.yml
@@ -17,5 +17,5 @@ inputs:
   
 runs:
   using: 'docker'
-  image: docker://sgn0/nuget-publish-action:main
+  image: docker://sgn0/nuget-publish-action:v2
   entrypoint: '/publish.sh'

--- a/sbt-unity/action.yml
+++ b/sbt-unity/action.yml
@@ -11,8 +11,7 @@ inputs:
     default: 'target/package.json'
 runs:
   using: 'docker'
-  image: docker://sgn0/sbt-unity-action:main
+  image: docker://sgn0/sbt-unity-action:v2
   entrypoint: '/build.sh'
   post-entrypoint: '/cleanup.sh'
-  
   

--- a/snapshot-bump/action.yml
+++ b/snapshot-bump/action.yml
@@ -10,4 +10,4 @@ inputs:
     default: 'packageVersion'
 runs:
   using: 'docker'
-  image: docker://sgn0/snapshot-bump-action:snapshot-bump-action
+  image: snapshot-bump/Dockerfile

--- a/snapshot-bump/action.yml
+++ b/snapshot-bump/action.yml
@@ -10,4 +10,4 @@ inputs:
     default: 'packageVersion'
 runs:
   using: 'docker'
-  image: snapshot-bump/Dockerfile
+  image: Dockerfile

--- a/snapshot-bump/action.yml
+++ b/snapshot-bump/action.yml
@@ -10,4 +10,4 @@ inputs:
     default: 'packageVersion'
 runs:
   using: 'docker'
-  image: Dockerfile
+  image: docker://sgn0/snapshot-bump-action:v2


### PR DESCRIPTION
Changes:

- docker based actions will now reference the `v2` tag explicitly in order to avoid future backwards incompatible changes. We'll need to remember to bump that on the next major release (or factor these actions into separate repos).
-  the build workflow takes an explicit tag for the images it produces. This allows us to produce builds without semvers, like develop builds.
- adds a develop build workflow